### PR TITLE
Fix entry order in webpack hot config

### DIFF
--- a/webpack.docs.hot.config.js
+++ b/webpack.docs.hot.config.js
@@ -30,6 +30,10 @@ const hotConfig = {
 };
 
 const mergedConfig = merge(devConfig, hotConfig);
-mergedConfig.entry.unshift('react-hot-loader/patch');
+mergedConfig.entry = [
+  'babel-polyfill',
+  'react-hot-loader/patch',
+  devConfig.entry[1],
+];
 
 module.exports = mergedConfig;


### PR DESCRIPTION
babel-polyfill should be before react-hot-loader entry in hot config